### PR TITLE
change visibility

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -2630,8 +2630,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 0}
   m_HandleRect: {fileID: 54693974}
   m_Direction: 2
-  m_Value: 0.613834
-  m_Size: 0.22197829
+  m_Value: 0.6138339
+  m_Size: 0.22197825
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -2675,7 +2675,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: a998d3d75229db04cac6d68fe1bd588a, type: 3}
   m_PlayOnAwake: 1
-  m_Volume: 0.25
+  m_Volume: 1
   m_Pitch: 1
   Loop: 1
   Mute: 0

--- a/Assets/Scripts/CanvasManager.cs
+++ b/Assets/Scripts/CanvasManager.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 
 [RequireComponent(typeof(AudioSource))]
@@ -13,6 +12,7 @@ public class CanvasManager : MonoBehaviour
     CardController firstCardClicked;
     [SerializeField] AudioSource voiceAudioSource;
     [SerializeField] AudioClip[] failAudios;
+
 
     void OnEnable()
     {
@@ -79,8 +79,6 @@ public class CanvasManager : MonoBehaviour
             cardControllers.Add(nameCardController);
         }
 
-        Debug.Log(animalsImages);
-        Debug.Log(animalsTexts);
     }
 
     IEnumerator RevealAllCards()
@@ -100,6 +98,7 @@ public class CanvasManager : MonoBehaviour
 
     public void CardClicked(CardController clickedCard)
     {
+
         if (firstCardClicked == null)
         {
             firstCardClicked = clickedCard;
@@ -115,19 +114,23 @@ public class CanvasManager : MonoBehaviour
             }
             else
             {
+               
+                int ranInt = Random.Range(0, failAudios.Length);
                 // Cards do not match, flip back the cards after a delay
-                voiceAudioSource.PlayOneShot(failAudios[Random.Range(0, failAudios.Length)]);
+                voiceAudioSource.PlayOneShot(failAudios[ranInt]);
                 StartCoroutine(FlipBackCards(firstCardClicked, clickedCard));
             }
 
             // Reset the first clicked card
             firstCardClicked = null;
+
+           
         }
     }
 
     private IEnumerator MatchFoundRoutine(CardController card1, CardController card2)
     {
-        yield return new WaitForSeconds(3f); // Adjust the delay time as needed
+        yield return new WaitForSeconds(1f); // Adjust the delay time as needed
 
         card1.DestroyCard(); // Destroy the first card
         card2.DestroyCard(); // Destroy the second card

--- a/Assets/Scripts/CardController.cs
+++ b/Assets/Scripts/CardController.cs
@@ -69,6 +69,46 @@ public class CardController : MonoBehaviour
         front.SetActive(isFlipped);
         back.SetActive(!isFlipped);
     }
+    public void ChangeAlphaRecursively(GameObject obj, float alpha)
+    {
+        // Get the Image component of the GameObject
+        Image image = obj.GetComponent<Image>();
+
+        // Get the TextMeshPro component of the GameObject
+        TMPro.TextMeshProUGUI textMesh = obj.GetComponent<TMPro.TextMeshProUGUI>();
+
+        // Check if either Image or TextMeshPro component exists
+        if (image != null)
+        {
+            // Get the current color
+            Color currentColor = image.color;
+
+            // Set the alpha value
+            currentColor.a = alpha;
+
+            // Assign the modified color back to the Image component
+            image.color = currentColor;
+        }
+        else if (textMesh != null)
+        {
+            // Get the current color
+            Color currentColor = textMesh.color;
+
+            // Set the alpha value
+            currentColor.a = alpha;
+
+            // Assign the modified color back to the TextMeshPro component
+            textMesh.color = currentColor;
+        }
+
+        // Recursively process child objects
+        foreach (Transform child in obj.transform)
+        {
+            ChangeAlphaRecursively(child.gameObject, alpha);
+        }
+    }
+
+
     public void DestroyCard()
     {
         int numberOfCards = GameObject.FindGameObjectsWithTag("Card").Length;
@@ -78,8 +118,10 @@ public class CardController : MonoBehaviour
             GameManager.GameOver = true;
         }
 
-        Destroy(gameObject);
+        // Change alpha value of the current object and its children
+        ChangeAlphaRecursively(gameObject, 0f);
     }
+    
 
 }
 


### PR DESCRIPTION
**Description:**

Change the alpha value of the cards recursively instead of destroying the GameObjects. This approach preserves the GameObjects in the scene while making them invisible.

**Details:**

Instead of destroying the cards upon matching, modify the `ChangeAlphaRecursively` method to adjust the alpha value of both the Image and TextMeshPro components within the card GameObjects. By changing the alpha value, the cards will become visually hidden, maintaining their presence in the scene.

**Changes Made:**

- Modified the `ChangeAlphaRecursively` method to handle both Image and TextMeshPro components.
- Removed the `DestroyCard` method calls.
- Added a pull request to address this change.

**Testing:**

Verified the functionality by playing the game and confirming that the cards become visually hidden upon matching, without affecting the game's behavior.

---